### PR TITLE
Fix the issue that labels and the axis title were not correctly shown when forceStepToMin is true

### DIFF
--- a/src/LiveChartsCore/Axis.cs
+++ b/src/LiveChartsCore/Axis.cs
@@ -554,6 +554,7 @@ public abstract class Axis<TDrawingContext, TTextGeometry, TLineGeometry>
         var axisTick = this.GetTick(chart.DrawMarginSize);
         var s = axisTick.Value;
         if (s < _minStep) s = _minStep;
+        if (_forceStepToMin) s = _minStep;
 
         var max = MaxLimit is null ? _visibleDataBounds.Max : MaxLimit.Value;
         var min = MinLimit is null ? _visibleDataBounds.Min : MinLimit.Value;


### PR DESCRIPTION
Set the variable which controls checking of the axis labels for their lengths to the value of `_minStep` when `_forceStepToMin` is true. This is similar to the code in line 249. Because this code was missing, the axis labels and axis title were not correctly sized in certain cases.